### PR TITLE
feat: use gpt-4o with system prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ gpt_evaluator/
 
 ### GPTClient (`src/gpt_client.py`)
 - OpenAI GPT API와의 통신을 담당
+- `gpt-4o` 모델을 사용하며 시스템 프롬프트와 질문을 전달해 답변을 생성
 - API 호출 및 응답 처리
 - 에러 핸들링
 
@@ -78,6 +79,12 @@ config = Config("config/config.json")
 
 # GPT 클라이언트 초기화
 gpt_client = GPTClient(config.get_api_key())
+
+# 시스템 프롬프트와 질문을 이용한 직접 호출
+answer = gpt_client.get_response(
+    question="2+2는?",
+    system_prompt="당신은 수학을 잘하는 친절한 도우미입니다.",
+)
 
 # 평가기 초기화
 evaluator = ResponseEvaluator(gpt_client)

--- a/src/gpt_client.py
+++ b/src/gpt_client.py
@@ -1,24 +1,25 @@
-"""
-GPT API와 통신하기 위한 클라이언트 모듈
-"""
-from typing import Dict, Any
+"""GPT API와 통신하기 위한 클라이언트 모듈"""
 import openai
+
 
 class GPTClient:
     def __init__(self, api_key: str):
         self.api_key = api_key
         openai.api_key = api_key
 
-    def get_response(self, prompt: str, **kwargs) -> Dict[str, Any]:
-        """
-        GPT API에 프롬프트를 보내고 응답을 받는 메서드
-        """
+    def get_response(self, question: str, system_prompt: str = "", **kwargs) -> str:
+        """GPT-4o 모델에 시스템 프롬프트와 질문을 보내 답변을 반환"""
         try:
+            messages = []
+            if system_prompt:
+                messages.append({"role": "system", "content": system_prompt})
+            messages.append({"role": "user", "content": question})
+
             response = openai.ChatCompletion.create(
-                model="gpt-3.5-turbo",
-                messages=[{"role": "user", "content": prompt}],
-                **kwargs
+                model="gpt-4o",
+                messages=messages,
+                **kwargs,
             )
-            return response
+            return response["choices"][0]["message"]["content"]
         except Exception as e:
             raise Exception(f"GPT API 호출 중 오류 발생: {str(e)}")


### PR DESCRIPTION
## Summary
- switch GPT client to gpt-4o and allow an optional system prompt for custom behavior
- document gpt-4o usage and add example of system prompt call

## Testing
- `python -m py_compile src/gpt_client.py`
- `python -m py_compile src/evaluator.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae7fc51eac832789807f86710f4785