### PR TITLE
feat: support random test sets for GPT evaluation

### DIFF
--- a/scripts/run_gpt_tests.py
+++ b/scripts/run_gpt_tests.py
@@ -1,0 +1,28 @@
+import argparse
+from src.config import Config
+from src.gpt_client import GPTClient
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run GPT classification on random test sets.")
+    parser.add_argument("--question-file", default="data/processed/test_questions.txt")
+    parser.add_argument("--set-size", type=int, required=True)
+    parser.add_argument("--set-count", type=int, default=1)
+    parser.add_argument("--output-dir", default="data/results")
+    parser.add_argument("--system-prompt", default="각 질문에 대해 '번호. 유형1, 유형2, 유형3, 유형4' 형식으로 답변하세요.")
+    parser.add_argument("--config", default="config/config.json")
+    args = parser.parse_args()
+
+    cfg = Config(args.config)
+    client = GPTClient(cfg.get_api_key())
+    client.run_test_sets(
+        question_file=args.question_file,
+        set_size=args.set_size,
+        set_count=args.set_count,
+        output_dir=args.output_dir,
+        system_prompt=args.system_prompt,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/gpt_client.py
+++ b/src/gpt_client.py
@@ -1,5 +1,7 @@
 """GPT API와 통신하기 위한 클라이언트 모듈"""
 import openai
+import random
+from pathlib import Path
 
 
 class GPTClient:
@@ -23,3 +25,35 @@ class GPTClient:
             return response["choices"][0]["message"]["content"]
         except Exception as e:
             raise Exception(f"GPT API 호출 중 오류 발생: {str(e)}")
+
+    def run_test_sets(
+        self,
+        question_file: str,
+        set_size: int,
+        set_count: int,
+        output_dir: str,
+        system_prompt: str = "",
+        **kwargs,
+    ) -> None:
+        """`test_questions.txt`에서 무작위 테스트 세트를 생성하고 GPT 응답을 저장"""
+        q_path = Path(question_file)
+        if not q_path.exists():
+            raise FileNotFoundError(f"질문 파일을 찾을 수 없습니다: {question_file}")
+
+        with q_path.open(encoding="utf-8") as f:
+            questions = [
+                line.strip().split(".", 1)[1].strip()
+                if "." in line else line.strip()
+                for line in f
+                if line.strip()
+            ]
+
+        out_dir = Path(output_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        for i in range(set_count):
+            sampled = random.sample(questions, set_size)
+            prompt = "\n".join(f"{j+1}. {q}" for j, q in enumerate(sampled))
+            response = self.get_response(prompt, system_prompt, **kwargs)
+            (out_dir / f"questions_set_{i+1}.txt").write_text(prompt, encoding="utf-8")
+            (out_dir / f"predictions_set_{i+1}.txt").write_text(response, encoding="utf-8")


### PR DESCRIPTION
## Summary
- add `run_test_sets` to `GPTClient` for generating random question batches and saving model answers
- provide `run_gpt_tests` CLI to invoke GPT on random subsets of `test_questions.txt`

## Testing
- `python -m py_compile src/gpt_client.py scripts/run_gpt_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae81c02be883279780566bbaa8419c