### PR TITLE
Use config-based defaults for test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,16 @@ result = evaluator.evaluate_response(
 )
 ```
 
+### 명령줄 실행
+
+무작위 테스트 세트에 대해 GPT 분류를 실행하려면 아래 명령만으로 충분합니다.
+
+```bash
+python scripts/run_gpt_tests.py
+```
+
+`config/system_prompt.txt`에 저장된 시스템 프롬프트와 기타 기본값을 자동으로 사용하므로 별도의 인자를 전달할 필요가 없습니다. 필요한 경우 `--set-size` 등 인자를 직접 지정해 덮어쓸 수 있습니다.
+
 ## 확장 가능성
 
 - 추가 평가 기준 구현

--- a/scripts/run_gpt_tests.py
+++ b/scripts/run_gpt_tests.py
@@ -1,27 +1,48 @@
+"""Utility script to run GPT classification on random test sets."""
+
 import argparse
+from pathlib import Path
+
 from src.config import Config
 from src.gpt_client import GPTClient
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Run GPT classification on random test sets.")
-    parser.add_argument("--question-file", default="data/processed/test_questions.txt")
-    parser.add_argument("--set-size", type=int, required=True)
+def _load_system_prompt(path: str) -> str:
+    """Read the system prompt from ``path`` if it exists."""
+    p = Path(path)
+    if not p.exists():
+        return ""
+    return p.read_text(encoding="utf-8").strip()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run GPT classification on random test sets."
+    )
+    parser.add_argument(
+        "--question-file", default="data/processed/test_questions.txt"
+    )
+    parser.add_argument("--set-size", type=int, default=10)
     parser.add_argument("--set-count", type=int, default=1)
     parser.add_argument("--output-dir", default="data/results")
-    parser.add_argument("--system-prompt", default="각 질문에 대해 '번호. 유형1, 유형2, 유형3, 유형4' 형식으로 답변하세요.")
+    parser.add_argument("--system-prompt", default=None)
+    parser.add_argument(
+        "--system-prompt-file", default="config/system_prompt.txt"
+    )
     parser.add_argument("--answer-file", default="data/processed/test_answers.txt")
     parser.add_argument("--config", default="config/config.json")
     args = parser.parse_args()
 
     cfg = Config(args.config)
+    system_prompt = args.system_prompt or _load_system_prompt(args.system_prompt_file)
+
     client = GPTClient(cfg.get_api_key())
     client.run_test_sets(
         question_file=args.question_file,
         set_size=args.set_size,
         set_count=args.set_count,
         output_dir=args.output_dir,
-        system_prompt=args.system_prompt,
+        system_prompt=system_prompt,
         answer_file=args.answer_file,
     )
 


### PR DESCRIPTION
## Summary
- load system prompt from `config/system_prompt.txt` by default
- provide default values for `run_gpt_tests.py` so it can run without arguments
- document command-line execution in README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae875bc2ac8327b14f48425642cdaa