### PR TITLE
Add configurable temperature with default 0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ gpt_evaluator/
 - `gpt-4o` 모델을 사용하며 시스템 프롬프트와 질문을 전달해 답변을 생성
 - API 호출 및 응답 처리
 - 에러 핸들링
+- 기본 `temperature`는 0.4이며 필요에 따라 `get_response` 호출 시 변경 가능
 
 ### ResponseEvaluator (`src/evaluator.py`)
 - 답변 평가 로직 구현
@@ -87,6 +88,7 @@ gpt_client = GPTClient(config.get_api_key())
 answer = gpt_client.get_response(
     question="2+2는?",
     system_prompt="당신은 수학을 잘하는 친절한 도우미입니다.",
+    temperature=0.4,  # 기본값은 0.4이며 필요 시 조절 가능
 )
 
 # 평가기 초기화

--- a/src/gpt_client.py
+++ b/src/gpt_client.py
@@ -10,11 +10,20 @@ class GPTClient:
     def __init__(self, api_key: str):
         self.client = OpenAI(api_key=api_key)
 
-    def get_response(self, question: str, system_prompt: str = "", **kwargs) -> str:
+    def get_response(
+        self,
+        question: str,
+        system_prompt: str = "",
+        temperature: float = 0.4,
+        **kwargs,
+    ) -> str:
         messages = []
         if system_prompt:
             messages.append({"role": "system", "content": system_prompt})
         messages.append({"role": "user", "content": question})
+
+        # 기본 temperature 값을 설정하되, 전달된 인자가 있으면 우선한다.
+        kwargs.setdefault("temperature", temperature)
 
         response = self.client.chat.completions.create(
             model="gpt-4o",


### PR DESCRIPTION
## Summary
- allow setting a temperature when requesting model responses, defaulting to 0.4
- document the new temperature parameter and show usage in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae927869088327a601464f6f7fc33c